### PR TITLE
Use /var/tmp instead of /tmp as tempdir

### DIFF
--- a/sdbootutil
+++ b/sdbootutil
@@ -19,7 +19,7 @@ arg_arch=
 
 rollback=()
 
-tmpdir=$(mktemp -d -t sdboot.XXXXXX)
+tmpdir=$(mktemp -d /var/tmp/sdboot.XXXXXX)
 cleanup()
 {
 	local i


### PR DESCRIPTION
fixes #2
Needs to be tested if it works on Microos